### PR TITLE
Add dev tooling and CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,22 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+          pre-commit install
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ The primary objective is to build a complete, reproducible Python project that t
 * **Implementation Plan (`dev/PLAN.md`)**: This file contains the comprehensive, state-of-the-art implementation plan for the entire ML workflow. It breaks down tasks into sub-tasks, specifies inputs, deliverables, tests, and acceptance criteria, and includes detailed implementation notes derived directly from the academic paper. **This is your primary guide for task execution.**
 
 * **Academic Paper (`dev/time_r1_paper/time_r1_paper.md`)**: For the foundational theoretical background, detailed algorithms, mathematical formulations, and experimental results, refer to the `time_r1_paper.md`. This paper provides the scientific basis for the Time-R1 framework.
+
+## ⚙️ Development Setup
+
+Install the project in editable mode with the development extras and set up
+pre-commit hooks:
+
+```bash
+pip install -e .[dev]
+pre-commit install
+```
+
+Running `pre-commit` will format the code with **black** and **isort**, lint with
+**ruff**, type-check with **mypy**, and execute the test suite using **pytest**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-cov",
+    "black",
+    "isort",
+    "ruff",
+    "mypy",
+    "pre-commit",
 ]
 
 [build-system]
@@ -29,3 +34,18 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"
+
+[tool.black]
+line-length = 88
+target-version = "py310"
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true


### PR DESCRIPTION
## Summary
- add black, isort, ruff, mypy, pre-commit to dev extras and configure tools
- introduce pre-commit hooks running style checks and pytest
- document development setup
- add GitHub Actions workflow for pre-commit

## Testing
- `pre-commit run --files pyproject.toml README.md .pre-commit-config.yaml .github/workflows/pre-commit.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd40f0be4833394b976903e08de77