### PR TITLE
Add dataset loader utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "jinja2",
     "torch>=2.2.0",
     "pytorch-lightning>=2.2.0",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -37,7 +38,7 @@ pythonpath = "src"
 
 [tool.black]
 line-length = 88
-target-version = "py310"
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
@@ -49,3 +50,4 @@ target-version = "py310"
 [tool.mypy]
 python_version = "3.10"
 check_untyped_defs = true
+ignore_missing_imports = true

--- a/scripts/prepare_ett_data.py
+++ b/scripts/prepare_ett_data.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+from time_r1.datasets.loader import load_dataset
+
+DEFAULT_URL = (
+    "https://raw.githubusercontent.com/zhouhaoyi/ETDataset/main/ETT-small/ETTh1.csv"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download and convert ETTh1 dataset")
+    parser.add_argument("--url", default=DEFAULT_URL, help="CSV source URL")
+    parser.add_argument(
+        "--output", default="data/ETTh1.parquet", help="Output parquet file"
+    )
+    args = parser.parse_args()
+
+    df = load_dataset("ETTh1", args.url)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out)
+    print(f"Saved {len(df)} rows to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/time_r1/datasets/__init__.py
+++ b/src/time_r1/datasets/__init__.py
@@ -1,12 +1,13 @@
 """Dataset utilities for Time-R1."""
 
+from .loader import DATASET_SCHEMAS, load_dataset
 from .nq import (
-    build_continuous,
-    parse_contract_filename,
-    roll_date,
-    read_contract,
     NQDataModule,
     NQDataset,
+    build_continuous,
+    parse_contract_filename,
+    read_contract,
+    roll_date,
 )
 
 __all__ = [
@@ -16,4 +17,6 @@ __all__ = [
     "read_contract",
     "NQDataModule",
     "NQDataset",
+    "load_dataset",
+    "DATASET_SCHEMAS",
 ]

--- a/src/time_r1/datasets/loader.py
+++ b/src/time_r1/datasets/loader.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+from pydantic import BaseModel
+
+
+class DatasetSchema(BaseModel):
+    """Simple schema describing a time series dataset."""
+
+    timestamp: Optional[str]
+    features: List[str]
+
+    def check(self, df: pd.DataFrame) -> None:
+        cols = [self.timestamp] + self.features if self.timestamp else self.features
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            raise ValueError(f"Missing columns: {missing}")
+        if self.timestamp:
+            df[self.timestamp] = pd.to_datetime(df[self.timestamp])
+            if df[self.timestamp].isnull().any():
+                raise ValueError("Invalid timestamps detected")
+
+
+DATASET_SCHEMAS: Dict[str, DatasetSchema] = {
+    "etth1": DatasetSchema(
+        timestamp="date",
+        features=[
+            "HUFL",
+            "HULL",
+            "MUFL",
+            "MULL",
+            "LUFL",
+            "LULL",
+            "OT",
+        ],
+    ),
+    "exchange": DatasetSchema(
+        timestamp=None,
+        features=[f"rate{i}" for i in range(8)],
+    ),
+}
+
+
+def load_dataset(name: str, path: str | Path) -> pd.DataFrame:
+    """Load a dataset by name and validate against its schema."""
+
+    key = name.lower()
+    if key not in DATASET_SCHEMAS:
+        raise KeyError(f"Unknown dataset '{name}'")
+    schema = DATASET_SCHEMAS[key]
+    p = Path(path)
+    read_kwargs: Dict[str, object] = {}
+    if p.suffix == ".gz":
+        read_kwargs["compression"] = "gzip"
+        read_kwargs["header"] = None
+    elif p.suffix == ".csv":
+        if schema.timestamp is None:
+            read_kwargs["header"] = None
+    df = pd.read_csv(p, **read_kwargs)
+    if schema.timestamp is None:
+        df.columns = schema.features
+        df.insert(0, "timestamp", range(len(df)))
+        schema = DatasetSchema(timestamp="timestamp", features=schema.features)
+    schema.check(df)
+    df = df[[schema.timestamp] + schema.features]
+    df.sort_values(schema.timestamp, inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+
+from time_r1.datasets import DATASET_SCHEMAS, load_dataset
+
+
+def test_etth1_loader(tmp_path):
+    data = [
+        ["2021-01-01 00:00:00", 1, 2, 3, 4, 5, 6, 7],
+        ["2021-01-01 01:00:00", 1, 2, 3, 4, 5, 6, 7],
+    ]
+    cols = ["date"] + DATASET_SCHEMAS["etth1"].features
+    df = pd.DataFrame(data, columns=cols)
+    csv_path = tmp_path / "etth1.csv"
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_dataset("ETTh1", csv_path)
+    assert list(loaded.columns) == ["date"] + DATASET_SCHEMAS["etth1"].features
+    assert len(loaded) == 2
+    assert pd.api.types.is_datetime64_any_dtype(loaded["date"])
+
+
+def test_schema_validation_missing_column(tmp_path):
+    data = [["2021-01-01 00:00:00", 1, 2, 3, 4, 5, 6]]  # one value short
+    cols = ["date"] + DATASET_SCHEMAS["etth1"].features[:-1]
+    df = pd.DataFrame(data, columns=cols)
+    csv_path = tmp_path / "bad.csv"
+    df.to_csv(csv_path, index=False)
+    with pytest.raises(ValueError):
+        load_dataset("etth1", csv_path)


### PR DESCRIPTION
## Summary
- implement generic dataset loading with pydantic-based schema checks
- expose loader in dataset package
- add ETTh1 data prep script
- support `pydantic` dependency and update mypy config
- test dataset loader

## Testing
- `ruff check src/time_r1/datasets/loader.py src/time_r1/datasets/__init__.py scripts/prepare_ett_data.py tests/test_loader.py`
- `mypy src/time_r1/datasets/loader.py src/time_r1/datasets/__init__.py scripts/prepare_ett_data.py tests/test_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe14668648333a2a9b7e4e271489b